### PR TITLE
Improve dashboard layout and CSV export button

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -238,10 +238,16 @@ def dashboard():
                 laatste_data = HealthData(user_id=user.id, date=datetime.utcnow().date())
                 db.session.add(laatste_data)
 
-            laatste_data.sleep_hours = float(request.form["sleep_hours"])
-            laatste_data.steps = int(request.form["steps"])
-            laatste_data.heart_rate = int(request.form["heart_rate"])
-            laatste_data.stress_level = request.form["stress_level"]
+            sleep_val = request.form.get("sleep_hours")
+            steps_val = request.form.get("steps")
+            heart_val = request.form.get("heart_rate")
+            stress_val = request.form.get("stress_level")
+
+            laatste_data.sleep_hours = float(sleep_val) if sleep_val else None
+            laatste_data.steps = int(steps_val) if steps_val else None
+            laatste_data.heart_rate = int(heart_val) if heart_val else None
+            laatste_data.stress_level = stress_val or None
+
             db.session.commit()
             flash("Gezondheidsgegevens opgeslagen.")
             return redirect(url_for("routes.dashboard"))

--- a/app/routes.py
+++ b/app/routes.py
@@ -435,7 +435,14 @@ def recommendations():
         slaapgem = round(sum(d.sleep_hours for d in data if d.sleep_hours) / len(data), 1)
         stappen = round(sum(d.steps for d in data if d.steps) / len(data), 1)
         hartslag = round(sum(d.heart_rate for d in data if d.heart_rate) / len(data), 1)
-        stress = round(sum(d.stress_level for d in data if d.stress_level) / len(data), 1)
+        # Stresslevels kunnen zowel numeriek als tekstueel opgeslagen zijn.
+        # Enkel numerieke waarden worden gemiddeld om fouten te voorkomen.
+        stress_values = [
+            int(d.stress_level)
+            for d in data
+            if d.stress_level is not None and str(d.stress_level).isdigit()
+        ]
+        stress = round(sum(stress_values) / len(stress_values), 1) if stress_values else 0
 
         if slaapgem < 6:
             recommendations.append("Je slaapt gemiddeld minder dan 6 uur. Probeer vroeger te gaan slapen.")

--- a/app/static/css/dashboard.css
+++ b/app/static/css/dashboard.css
@@ -44,3 +44,41 @@ button:hover {
     background-color: #d1e7dd;
     color: #0f5132;
 }
+
+/* Layout improvements */
+.page-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+}
+
+.card-container {
+    display: flex;
+    gap: 1rem;
+}
+
+.dashboard-card {
+    flex: 1;
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+.btn-download {
+    display: inline-block;
+    background-color: #28a745;
+    color: white;
+    padding: 0.6rem 1.2rem;
+    border-radius: 6px;
+    text-decoration: none;
+    margin-top: 1rem;
+}
+
+.btn-download:hover {
+    background-color: #218838;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,6 +4,9 @@
 {% block title %}Dashboard - VitalView{% endblock %}
 
 {% block content %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+
+<div class="page-container">
 <h1>Welkom terug, {{ user.voornaam or 'gebruiker' }}!</h1>
 
 <form method="post" class="user-info-form">
@@ -20,10 +23,10 @@
 
 <form method="post" class="health-form">
   <h2>📊 Gezondheidsgegevens</h2>
-  <label>Slaapuren (laatste): <input type="number" name="sleep_hours" step="0.1" value="{{ laatste_data.sleep_hours or '' }}"></label><br>
-  <label>Stappen: <input type="number" name="steps" value="{{ laatste_data.steps or '' }}"></label><br>
-  <label>Hartslag: <input type="number" name="heart_rate" value="{{ laatste_data.heart_rate or '' }}"></label><br>
-  <label>Stressniveau: <input type="text" name="stress_level" value="{{ laatste_data.stress_level or '' }}"></label><br>
+  <label>Slaapuren (laatste): <input type="number" name="sleep_hours" step="0.1" value="{{ laatste_data.sleep_hours or '' }}" required></label><br>
+  <label>Stappen: <input type="number" name="steps" value="{{ laatste_data.steps or '' }}" required></label><br>
+  <label>Hartslag: <input type="number" name="heart_rate" value="{{ laatste_data.heart_rate or '' }}" required></label><br>
+  <label>Stressniveau: <input type="text" name="stress_level" value="{{ laatste_data.stress_level or '' }}" required></label><br>
   <button type="submit" name="update_health">Opslaan gezondheid</button>
 </form>
 
@@ -43,5 +46,9 @@
         <h3>Hartslag</h3>
         <p>Gemiddeld: {{ hartslag_avg }} bpm</p>
     </div>
+</div>
+
+<a href="{{ url_for('routes.export_csv') }}" class="btn-download">Download CSV</a>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style dashboard with a container and cards
- add CSV download button
- require input for health data
- handle empty inputs server-side

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685117320ccc83328fc537d0b47ba9b3